### PR TITLE
fixing anthropic call + add support for replicate and palm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ base_requirements = [
     "prompt_toolkit==3.0.38",
 
 ]
-anthropic_requirements = ["anthropic>=0.2.8"]
+anthropic_requirements = ["litellm>=0.1.2291"]
 cohere_requirements = ["cohere>=4.3.1"]
 hf_requirements = ["transformers>=4.27.4"]
 bard_requirements = ["bardapi==0.1.11"]


### PR DESCRIPTION
Hey @elliottower, 

Noticed you had an old anthropic all (they updated their sdk a few days ago). Wanted to see if we could fix that and add support for some new LLM providers.  I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and wanted to help out.

Replaced the Anthropic raw endpoint call with a litellm `completions` call, this should ensure you're not impacted by any underlying changes. This call also adds support for new providers like Replicate, PaLM and a few you already support like Claude, Cohere, Azure, and OpenAI. 

The code is pretty similar to the OpenAI class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.

Happy to make any additional changes as required 😊