### PR TITLE
Umshini envs: add attack/defend role to info, add more info to printouts

### DIFF
--- a/chatarena/backends/openai.py
+++ b/chatarena/backends/openai.py
@@ -23,8 +23,8 @@ else:
 # Default config follows the OpenAI playground
 DEFAULT_TEMPERATURE = 0.7
 DEFAULT_MAX_TOKENS = 256
-# DEFAULT_MODEL = "gpt-3.5-turbo"
-DEFAULT_MODEL = "gpt-4-0613"
+DEFAULT_MODEL = "gpt-3.5-turbo"
+# DEFAULT_MODEL = "gpt-4-0613"
 
 END_OF_MESSAGE = "<EOS>"  # End of message token specified by us not OpenAI
 STOP = ("<|endoftext|>", END_OF_MESSAGE)  # End of sentence token

--- a/chatarena/environments/umshini/pettingzoo_wrapper.py
+++ b/chatarena/environments/umshini/pettingzoo_wrapper.py
@@ -281,6 +281,15 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
             }
             self.infos[agent]["player_name"] = self.agent_selection
 
+            # Role in symmetric environments
+            if hasattr(self._env, "_current_phase"):
+                if self._env._current_phase == "player_2_attack" or self._env._current_phase == "end":
+                    self.infos[self.possible_agents[0]]["role"] = "defender"
+                    self.infos[self.possible_agents[1]]["role"] = "attacker"
+                else:
+                    self.infos[self.possible_agents[0]]["role"] = "attacker"
+                    self.infos[self.possible_agents[1]]["role"] = "defender"
+
             # info: generate string of full chat log
             if self.string_observation is True:
                 all_messages_string = ""
@@ -363,6 +372,15 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
             for m in messages:
                 all_messages_string += f"[{m.agent_name}->all]: {m.content}\n"
             info["all_messages_string"] = all_messages_string
+
+        # Role in symmetric environments
+        if hasattr(self._env, "_current_phase"):
+            if self._env._current_phase == "player_2_attack" or self._env._current_phase == "end":
+                self.infos[self.possible_agents[0]]["role"] = "defender"
+                self.infos[self.possible_agents[1]]["role"] = "attacker"
+            else:
+                self.infos[self.possible_agents[0]]["role"] = "attacker"
+                self.infos[self.possible_agents[1]]["role"] = "defender"
 
         # info: environment specific information
         if hasattr(self, "restricted_action"):

--- a/chatarena/environments/umshini/symmetric_content_moderation.py
+++ b/chatarena/environments/umshini/symmetric_content_moderation.py
@@ -129,7 +129,7 @@ The restricted action is: {moderator_prompt_input}
                 )
                 if self._current_turn == self._round_length:
                     # swap roles
-                    self._moderator_speak("Roles are being swapped")
+                    self._moderator_speak(f"Roles are being swapped. {self.player_names[0]} is defending, and {self.player_names[1]} is attacking.")
                     self.player_names.reverse()
                     self.agent_selector.reinit(self.player_names)
                 return timestep

--- a/chatarena/environments/umshini/symmetric_deception.py
+++ b/chatarena/environments/umshini/symmetric_deception.py
@@ -121,7 +121,7 @@ The restricted action is: {moderator_prompt_input}
                 )
                 # if it is the end of the first round, swap roles
                 if self._current_turn == self._round_length:
-                    self._moderator_speak("Roles are being swapped")
+                    self._moderator_speak(f"Roles are being swapped. {self.player_names[0]} is defending, and {self.player_names[1]} is attacking.")
                     self.player_names.reverse()
                     self.agent_selector.reinit(self.player_names)
                 return timestep

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ all_requirements = all_backends + all_envs + gradio_requirements
 
 setup(
     name="chatarena",
-    version="0.1.12.9",
+    version="0.1.12.10",
     author="Yuxiang Wu",
     author_email="yuxiang.cs@gmail.com",
     description="",


### PR DESCRIPTION
These are just some minor quality of life changes that allow easier creation of bots, which can easily access what role they are currently playing.

I branched this from main so merging this into dev will also make dev be up to date.