### PR TITLE
Fix minor bug in umshini environments: role not always shown in info

### DIFF
--- a/chatarena/environments/umshini/pettingzoo_wrapper.py
+++ b/chatarena/environments/umshini/pettingzoo_wrapper.py
@@ -246,8 +246,6 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
         # Observations and infos are calculated in step(), but need to be calculated before the first step() call
         elif type(agent) != str:
             raise TypeError("AgentID must be a string")
-        elif self.observations[agent] != {}:
-            return self.observations[agent]
         else:
             # get only the messages that this agent can see
             messages = self._env.get_observation(agent)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatarena"
-version = "0.1.12.10"
+version = "0.1.12.11"
 authors = [
     { name = "Yuxiang Wu", email = "yuxiang.cs@gmail.com" },
 ]


### PR DESCRIPTION
In certain edge cases the `role` attribute was not included in the info dict, this PR fixes that