### PR TITLE
Umshini rendering update (attack/defend color text)

### DIFF
--- a/chatarena/environments/umshini/pettingzoo_wrapper.py
+++ b/chatarena/environments/umshini/pettingzoo_wrapper.py
@@ -7,6 +7,7 @@ import string
 
 from typing import List
 
+from colorama import Fore
 from chatarena.environments import Environment
 from chatarena.environments.base import TimeStep
 from chatarena.message import Message
@@ -227,9 +228,21 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
                 raise Exception("New messages not found")
             else:
                 for message in new_messages:
-                    print(
-                        f"[{message.agent_name}->{message.visible_to}]: {message.content}\n"
-                    )
+                    # Don't repeat things from previous turns
+                    if not self.current_turn > message.turn:
+                        if message.agent_name == "Moderator":
+                            color = Fore.BLACK
+                            role = ""
+                        else:
+                            if self.infos[message.agent_name]["role"] == "attacker":
+                                color = Fore.RED
+                                role = "(attacker)"
+                            else:
+                                color = Fore.BLUE
+                                role = "(defender)"
+                        print(
+                            color + f"[{message.agent_name} {role} -> {message.visible_to}]: {message.content}\n "
+                        )
 
     def observe(self, agent: AgentID) -> ObsType:
         """observe.
@@ -379,6 +392,8 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
             else:
                 self.infos[self.possible_agents[0]]["role"] = "attacker"
                 self.infos[self.possible_agents[1]]["role"] = "defender"
+
+        info["role"] = self.infos[self.agent_selection]["role"]
 
         # info: environment specific information
         if hasattr(self, "restricted_action"):

--- a/chatarena/environments/umshini/symmetric_content_moderation.py
+++ b/chatarena/environments/umshini/symmetric_content_moderation.py
@@ -121,23 +121,22 @@ The restricted action is: {moderator_prompt_input}
                 # it is player 2's turn to respond to player 1's query
                 # they should be judged on whether they allow the restricted action
                 # return rewards this step
-                rews = self.get_rewards()
-                timestep = TimeStep(
-                    observation=self.get_observation(player_name=player_name),
-                    reward=rews,
-                    terminal=False,
-                )
                 if self._current_turn == self._round_length:
                     # swap roles
                     self._moderator_speak(f"Roles are being swapped. {self.player_names[0]} is defending, and {self.player_names[1]} is attacking.")
                     self.player_names.reverse()
                     self.agent_selector.reinit(self.player_names)
+                    self._current_phase = "player_2_attack"
+                timestep = TimeStep(
+                    observation=self.get_observation(player_name=player_name),
+                    reward=self.get_rewards(),
+                    terminal=False,
+                )
                 return timestep
 
         elif self._current_turn <= 2 * self._round_length:
-            self._current_phase = "player_2_attack"
             if self._current_turn % 2 == 1:
-                # it is player 1's turn to go first in attacking
+                # it is player 2's turn to go first in attacking
                 # add their message to the pool, return no reward
                 return TimeStep(
                     observation=self.get_observation(player_name=player_name),
@@ -151,10 +150,9 @@ The restricted action is: {moderator_prompt_input}
                 is_now_terminal = self._current_turn == 2 * self._round_length
 
                 # get the rewards before getting the observation, so that the moderator's final message is displayed (winner)
-                rews = self.get_rewards()
                 return TimeStep(
                     observation=self.get_observation(player_name=player_name),
-                    reward=rews,
+                    reward=self.get_rewards(),
                     terminal=is_now_terminal,
                 )
         else:

--- a/chatarena/environments/umshini/symmetric_deception.py
+++ b/chatarena/environments/umshini/symmetric_deception.py
@@ -124,6 +124,12 @@ The restricted action is: {moderator_prompt_input}
                     self._moderator_speak(f"Roles are being swapped. {self.player_names[0]} is defending, and {self.player_names[1]} is attacking.")
                     self.player_names.reverse()
                     self.agent_selector.reinit(self.player_names)
+                    self._current_phase = "player_2_attack"
+                timestep = TimeStep(
+                    observation=self.get_observation(player_name=player_name),
+                    reward=self.get_rewards(),
+                    terminal=False,
+                )
                 return timestep
         elif self._current_turn <= 2 * self._round_length + 1:
             self._current_phase = "player_2_attack"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ bard = ["bardapi==0.1.11"]
 langchain = ["langchain>=0.0.135"]
 gradio = ["gradio>=3.34.0"]
 pettingzoo = ["pettingzoo[classic]>=1.23.1"]
-umshini = ["pettingzoo>=1.23.1", "langchain>=0.0.135"]
+umshini = ["pettingzoo>=1.23.1", "langchain>=0.0.135", "colorama>=0.4.6"]
 all_backends = ["anthropic>=0.2.8", "cohere>=4.3.1", "transformers>=4.27.4", "bardapi==0.1.11", "langchain>=0.0.135"]
 all_envs = ["pettingzoo[classic]>=1.23.1", "langchain>=0.0.135"]
 all = ["anthropic>=0.2.8", "cohere>=4.3.1", "transformers>=4.27.4", "gradio>=3.34.0", "pettingzoo>=1.23.1",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ bard_requirements = ["bardapi==0.1.11"]
 langchain_requirements = ["langchain>=0.0.135"]
 gradio_requirements = ["gradio>=3.34.0"]
 pettingzoo_requirements = ["pettingzoo[classic]>=1.23.1", "chess==1.9.4"]
-umshini_requirements = ["pettingzoo>=1.23.1", "langchain>=0.0.135"]
+umshini_requirements = ["pettingzoo>=1.23.1", "langchain>=0.0.135", "colorama>=0.4.6"]
 
 all_backends = anthropic_requirements + cohere_requirements + hf_requirements + bard_requirements + \
                langchain_requirements


### PR DESCRIPTION
Minor PR incorporating some changes we've done in our starter scripts that I figure might as well be in the env itself, helps a bit with telling when they are hallucinating (e.g., if there are two [Agent1] [Agent 2] within the same block of red text, you know that agent is trying to play as both agents)

Added the colorama requirement as that's what we've used for simple color printing