### PR TITLE
Umshini envs: remove printing of scores in symmetric envs

### DIFF
--- a/chatarena/environments/umshini/symmetric_content_moderation.py
+++ b/chatarena/environments/umshini/symmetric_content_moderation.py
@@ -125,7 +125,6 @@ The moderation policy is: {moderator_prompt_input}
                 # they should be judged on whether they allow the restricted action
                 # return rewards this step
                 rews = self.get_rewards()
-                self._moderator_speak(f"SCORES: {rews}")
                 if self._current_turn == self._round_length:
                     # swap roles
                     self._moderator_speak(f"Roles are being swapped. {self.player_names[0]} is defending, and {self.player_names[1]} is attacking.")
@@ -156,7 +155,6 @@ The moderation policy is: {moderator_prompt_input}
 
                 # get the rewards before getting the observation, so that the moderator's final message is displayed (winner)
                 rews = self.get_rewards()
-                self._moderator_speak(f"SCORES: {rews}")
                 return TimeStep(
                     observation=self.get_observation(player_name=player_name),
                     reward=rews,

--- a/chatarena/environments/umshini/symmetric_deception.py
+++ b/chatarena/environments/umshini/symmetric_deception.py
@@ -122,7 +122,6 @@ The restricted action is: {moderator_prompt_input}
                 # return rewards this step
                 # if it is the end of the first round, swap roles
                 rews = self.get_rewards()
-                self._moderator_speak(f"SCORES: {rews}")
                 if self._current_turn == self._round_length:
                     self._moderator_speak(f"Roles are being swapped. {self.player_names[0]} is defending, and {self.player_names[1]} is attacking.")
                     self.player_names.reverse()
@@ -151,7 +150,6 @@ The restricted action is: {moderator_prompt_input}
 
                 # get the rewards before getting the observation, so that the moderator's final message is displayed (not currently used))
                 rews = self.get_rewards()
-                self._moderator_speak(f"SCORES: {rews}")
                 return TimeStep(
                     observation=self.get_observation(player_name=player_name),
                     reward=rews,


### PR DESCRIPTION
Turns out these made agents perform poorly because they got confused, so I'm just removing it. In the future it may be nice for the moderator to say "VIOLATION? False" to give them information, but I suspect it would also lead to hallucination.