### PR TITLE
Add python-publish workflow to automate pypi releases

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,65 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: build-publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-wheels:
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-latest
+          python: 38
+          platform: manylinux_x86_64
+        - os: ubuntu-latest
+          python: 39
+          platform: manylinux_x86_64
+        - os: ubuntu-latest
+          python: 310
+          platform: manylinux_x86_64
+        - os: ubuntu-latest
+          python: 311
+          platform: manylinux_x86_64
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: python -m pip install --upgrade setuptools wheel
+    - name: Build wheels
+      run: python setup.py sdist bdist_wheel
+    - name: Store wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist
+
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+    - build-wheels
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - name: Download dists
+      uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Simple CI pipeline using a stored pypi access token, same as how is done on other Farama repos