### PR TITLE
Update upload-artifact and download-artifact versions (deprecated node version)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Build wheels
       run: python setup.py sdist bdist_wheel
     - name: Store wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: dist
 
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
     - name: Download dists
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: artifact
         path: dist


### PR DESCRIPTION
Just removing some warning messages in the CI workflows