### PR TITLE
Update OpenAI backend to use 1.0.0 API (errors in local testing)

### DIFF
--- a/chatarena/backends/openai.py
+++ b/chatarena/backends/openai.py
@@ -13,12 +13,12 @@ except ImportError:
     is_openai_available = False
     # logging.warning("openai package is not installed")
 else:
-    client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
-    if client.api_key is None:
+    try:
+        client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+        is_openai_available = True
+    except openai.OpenAIError:
         # logging.warning("OpenAI API key is not set. Please set the environment variable OPENAI_API_KEY")
         is_openai_available = False
-    else:
-        is_openai_available = True
 
 # Default config follows the OpenAI playground
 DEFAULT_TEMPERATURE = 0.7

--- a/chatarena/backends/openai.py
+++ b/chatarena/backends/openai.py
@@ -13,8 +13,8 @@ except ImportError:
     is_openai_available = False
     # logging.warning("openai package is not installed")
 else:
-    openai.api_key = os.environ.get("OPENAI_API_KEY")
-    if openai.api_key is None:
+    client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    if client.api_key is None:
         # logging.warning("OpenAI API key is not set. Please set the environment variable OPENAI_API_KEY")
         is_openai_available = False
     else:
@@ -72,7 +72,7 @@ class OpenAIChat(IntelligenceBackend):
 
     @retry(stop=stop_after_attempt(6), wait=wait_random_exponential(min=1, max=60))
     def _get_response(self, messages):
-        completion = openai.ChatCompletion.create(
+        completion = client.chat.completions.create(
             model=self.model,
             messages=messages,
             temperature=self.temperature,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "openai>=0.27.2",
+    "openai>=1.0.0",
     "tenacity==8.2.2",
     "rich==13.3.3",
     "prompt_toolkit==3.0.38",


### PR DESCRIPTION
The gradio app on HuggingFace spaces seem to have issues with OpenAI version, we could restrict it to use less than 1.0.0 but I figure it's easier and more future proof to just upgrade it. I ran openai migrate which is the recommended use.