### PR TITLE
Fix slow CI tests (using `pytest-xdist`)

### DIFF
--- a/.github/workflows/environments-test-azure-openai.yml
+++ b/.github/workflows/environments-test-azure-openai.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Umshini Environments Test
         run: |
           python -c 'import os; print("AZURE_OPENAI_API_KEY visible in os.environ:", os.getenv("AZURE_OPENAI_API_KEY"))'
-          pytest -v tests/unit/test_umshini_environments.py
+          pytest -v -n auto tests/unit/test_umshini_environments.py

--- a/.github/workflows/environments-test-openai.yml
+++ b/.github/workflows/environments-test-openai.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Regular Environments Test
         run: |
           python -c 'import os; print("OPENAI_API_KEY visible in os.environ:", os.getenv("OPENAI_API_KEY"))'
-          pytest -v tests
+          pytest -v -n auto tests
       - name: Umshini Environments Test
         run: |
           python -c 'import os; print("OPENAI_API_KEY visible in os.environ:", os.getenv("OPENAI_API_KEY"))'
-          pytest -v tests/unit/test_umshini_environments.py
+          pytest -v -n auto tests/unit/test_umshini_environments.py


### PR DESCRIPTION
Had disabled this before because I thought it may have been the reason environment variables weren't working but it wasn't. Tests passed in 4 minutes, hoping this speeds it up a bit.