### PR TITLE
Add xfail to capture PettingZoo ValueError (from invalid actions)

### DIFF
--- a/tests/unit/test_arena.py
+++ b/tests/unit/test_arena.py
@@ -164,6 +164,7 @@ class TestArena(TestCase):
         "OpenAI API key must be set to run this test.",
     )
     @pytest.mark.xfail(raises=chatarena.arena.TooManyInvalidActions)
+    @pytest.mark.xfail(raises=ValueError)
     def test_arena_11(self):
         arena = Arena.from_config(
             os.path.join(EXAMPLES_DIR, "pettingzoo_tictactoe.json")


### PR DESCRIPTION
This is just a random test that fails sometimes, we have an xfail for one type of error related to invalid actions but not the other potential error