### PR TITLE
Fix @pytest.xfail syntax for sometimes failing test

### DIFF
--- a/tests/unit/test_arena.py
+++ b/tests/unit/test_arena.py
@@ -163,8 +163,7 @@ class TestArena(TestCase):
         not os.getenv("OPENAI_API_KEY"),
         "OpenAI API key must be set to run this test.",
     )
-    @pytest.mark.xfail(raises=chatarena.arena.TooManyInvalidActions)
-    @pytest.mark.xfail(raises=ValueError)
+    @pytest.mark.xfail(raises=(chatarena.arena.TooManyInvalidActions, ValueError))
     def test_arena_11(self):
         arena = Arena.from_config(
             os.path.join(EXAMPLES_DIR, "pettingzoo_tictactoe.json")


### PR DESCRIPTION
The previous PR seemed not to work properly (see it still failing https://github.com/Farama-Foundation/chatarena/actions/runs/7009582445/job/19068352955 even though it's supposed to capture the error)