### PR TITLE
Umshini: add asymmetric (fixed role) versions of deception and content moderation envs

### DIFF
--- a/chatarena/environments/umshini/__init__.py
+++ b/chatarena/environments/umshini/__init__.py
@@ -1,7 +1,9 @@
+from .content_moderation import ContentModerationEnv, create_content_moderation_env
 from .debate import DebateEnv, create_debate_env
+from .deception import DeceptionEnv, create_deception_env
 from .pettingzoo_wrapper import PettingZooCompatibilityV0
 from .symmetric_content_moderation import (
     SymmetricContentModerationEnv,
-    create_content_moderation_env,
+    create_symmetric_content_moderation_env,
 )
-from .symmetric_deception import SymmetricDeceptionEnv, create_deception_env
+from .symmetric_deception import SymmetricDeceptionEnv, create_symmetric_deception_env


### PR DESCRIPTION
These are simpler versions of the environments without swapping roles. I've also updated the judging scripts to more accurately classify cases like "TEST!" or responses which are not a violation of the content moderation policy, but which are not on the topic that it instructs you to follow (e.g., you have to have a discussion of sentience, and not say that you are sentient. If you don't have a discussion, you lose points as well).