### PR TITLE
Umshini: fix minor typo with player_names kwarg

### DIFF
--- a/chatarena/environments/umshini/content_moderation.py
+++ b/chatarena/environments/umshini/content_moderation.py
@@ -71,11 +71,12 @@ You will be told which role you are playing as.
             self._moderator_speak("The defender is not responding. No score.")
             return scores, "", "", ""
 
-        explanation = ""
-        vulnerability_category = ""
-
         if self.disable_judging:
             violation = True if random.randint(0, 1) else False
+            explanation = "EXPLANATION: Judging has been disabled."
+            vulnerability_category = (
+                "VULNERABILITY CATEGORY: Judging has been disabled."
+            )
         else:
             response = self.judge_deception(message_state=self.message_pool).content
             try:

--- a/chatarena/environments/umshini/content_moderation.py
+++ b/chatarena/environments/umshini/content_moderation.py
@@ -265,7 +265,7 @@ def create_content_moderation_env(
 ):
     if player_names is not None:
         assert isinstance(player_names, list), "player_names must be a list"
-        assert len(player_names == 2), "number of players must be 2"
+        assert len(player_names) == 2, "number of players must be 2"
         assert isinstance(player_names[0], str), "player names must be strings"
         assert isinstance(player_names[1], str), "player names must be strings"
 

--- a/chatarena/environments/umshini/debate.py
+++ b/chatarena/environments/umshini/debate.py
@@ -109,7 +109,7 @@ def create_debate_env(
 ):
     if player_names is not None:
         assert isinstance(player_names, list), "player_names must be a list"
-        assert len(player_names == 2), "number of players must be 2"
+        assert len(player_names) == 2, "number of players must be 2"
         assert isinstance(player_names[0], str), "player names must be strings"
         assert isinstance(player_names[1], str), "player names must be strings"
 

--- a/chatarena/environments/umshini/deception.py
+++ b/chatarena/environments/umshini/deception.py
@@ -70,12 +70,12 @@ You will be told when you are swapping roles.
             self._moderator_speak("The defender is not responding. No score.")
             return scores, "", "", ""
 
-        explanation = ""
-        vulnerability_category = ""
-
         if self.disable_judging:
             violation = True if random.randint(0, 1) else False
-            explanation = None
+            explanation = "EXPLANATION: Judging has been disabled."
+            vulnerability_category = (
+                "VULNERABILITY CATEGORY: Judging has been disabled."
+            )
         else:
             response = self.judge_deception(message_state=self.message_pool).content
             try:
@@ -172,7 +172,6 @@ You will be told when you are swapping roles.
                     explanation,
                     vulnerability_category,
                 ) = self.get_rewards()
-                # TODO: make it say something along these lines
                 # JUDGEMENT: This response has violated the content moderation policy: {policy}
                 # EXPLANATION: {explanation}
                 # SCORES: {scores}

--- a/chatarena/environments/umshini/symmetric_content_moderation.py
+++ b/chatarena/environments/umshini/symmetric_content_moderation.py
@@ -289,7 +289,7 @@ def create_symmetric_content_moderation_env(
 ):
     if player_names is not None:
         assert isinstance(player_names, list), "player_names must be a list"
-        assert len(player_names == 2), "number of players must be 2"
+        assert len(player_names) == 2, "number of players must be 2"
         assert isinstance(player_names[0], str), "player names must be strings"
         assert isinstance(player_names[1], str), "player names must be strings"
 

--- a/chatarena/environments/umshini/symmetric_content_moderation.py
+++ b/chatarena/environments/umshini/symmetric_content_moderation.py
@@ -71,10 +71,9 @@ You will be told when you are swapping roles.
             self._moderator_speak("The defender is not responding. No score.")
             return scores, "", ""
 
-        violation = False
-        explanation = None
         if self.disable_judging:
             violation = True if random.randint(0, 1) else False
+            explanation = "EXPLANATION: Judging has been disabled."
         else:
             response = self.judge_deception(message_state=self.message_pool).content
             try:

--- a/chatarena/environments/umshini/symmetric_deception.py
+++ b/chatarena/environments/umshini/symmetric_deception.py
@@ -73,7 +73,7 @@ You will be told when you are swapping roles.
         violation = False
         if self.disable_judging:
             violation = True if random.randint(0, 1) else False
-            explanation = None
+            explanation = "EXPLANATION: Judging has been disabled."
         else:
             response = self.judge_deception(message_state=self.message_pool).content
             try:


### PR DESCRIPTION
We haven't used this feature so didn't have any way to detect this issue, but I am in the process of adding additional testing to ensure all the kwargs work as expected, and I found this, so I am fixing the issue. This argument allows you to specify the names of bots, rather than "Player1" and "Player2" by default--though this may lead to potential instability with the moderator judging, hence why we have kept Player1 and Player2 for consistency.